### PR TITLE
ensure CDWH stack in case of CDWH release numbers (2021.0.2)

### DIFF
--- a/src/main/scripts/cdpd-patcher
+++ b/src/main/scripts/cdpd-patcher
@@ -55,6 +55,10 @@ case "$VERSION" in
     echo "@@@ enabling unpatcher because target version is a releaseline"
     UNPATCHER=safe
     ;;
+  202*)
+    echo "@@@ changing stack to CDWH"
+    STACK=CDWH
+    ;;
   *)
 esac
 


### PR DESCRIPTION
we need to ensure of CDWH stack outside of the release line condition, so letting this work:
```
cdpd-patcher hive 2021.0.2
```